### PR TITLE
Support of @mixin annotation

### DIFF
--- a/src/BuilderMethodExtension.php
+++ b/src/BuilderMethodExtension.php
@@ -51,7 +51,13 @@ final class BuilderMethodExtension implements MethodsClassReflectionExtension, B
      */
     public function hasMethod(ClassReflection $classReflection, string $methodName): bool
     {
-        if ($classReflection->isSubclassOf(Model::class) && !isset($this->methods[$classReflection->getName()])) {
+        if (!isset($this->methods[$classReflection->getName()]) && (
+                $classReflection->isSubclassOf(Model::class)
+                || preg_match(
+                    '/@mixin\s+' . preg_quote('\\' . Builder::class) . '/',
+                    (string) $classReflection->getNativeReflection()->getDocComment()
+                )
+        )) {
             $builder = $this->broker->getClass(Builder::class);
             $this->methods[$classReflection->getName()] = $this->createWrappedMethods($classReflection, $builder);
 

--- a/src/FacadeMethodExtension.php
+++ b/src/FacadeMethodExtension.php
@@ -69,6 +69,17 @@ final class FacadeMethodExtension implements MethodsClassReflectionExtension, Br
                 $instanceReflection = $this->broker->getClass(get_class($instance));
                 $this->methods[$classReflection->getName()] = $this->createMethods($classReflection, $instanceReflection);
 
+                if (preg_match_all(
+                    '/@mixin\s+([\w\\\\]+)/',
+                    (string) $instanceReflection->getNativeReflection()->getDocComment(),
+                    $mixins
+                )) {
+                    foreach ($mixins[1] as $mixin) {
+                        $mixinInstanceReflection = $this->broker->getClass($mixin);
+                        $this->methods[$classReflection->getName()] += $this->createMethods($classReflection, $mixinInstanceReflection);
+                    }
+                }
+
                 if (isset($this->extensions[$instanceReflection->getName()])) {
                     $extensionMethod = $this->extensions[$instanceReflection->getName()];
                     $extensionReflection = $this->broker->getClass(get_class($instance->$extensionMethod()));

--- a/src/FacadeMethodExtension.php
+++ b/src/FacadeMethodExtension.php
@@ -10,6 +10,8 @@ use PHPStan\Reflection\BrokerAwareExtension;
 use PHPStan\Reflection\ClassReflection;
 use PHPStan\Reflection\MethodsClassReflectionExtension;
 use PHPStan\Reflection\MethodReflection;
+use Weebly\PHPStan\Laravel\Utils\AnnotationsHelper;
+use PHPStan\Broker\ClassNotFoundException;
 
 final class FacadeMethodExtension implements MethodsClassReflectionExtension, BrokerAwareExtension
 {
@@ -37,13 +39,20 @@ final class FacadeMethodExtension implements MethodsClassReflectionExtension, Br
     private $methodReflectionFactory;
 
     /**
+     * @var AnnotationsHelper
+     */
+    private $annotationsHelper;
+
+    /**
      * FacadeMethodExtension constructor.
      *
      * @param \Weebly\PHPStan\Laravel\MethodReflectionFactory $methodReflectionFactory
+     * @param AnnotationsHelper $annotationsHelper
      */
-    public function __construct(MethodReflectionFactory $methodReflectionFactory)
+    public function __construct(MethodReflectionFactory $methodReflectionFactory, AnnotationsHelper $annotationsHelper)
     {
         $this->methodReflectionFactory = $methodReflectionFactory;
+        $this->annotationsHelper = $annotationsHelper;
     }
 
     /**
@@ -69,15 +78,13 @@ final class FacadeMethodExtension implements MethodsClassReflectionExtension, Br
                 $instanceReflection = $this->broker->getClass(get_class($instance));
                 $this->methods[$classReflection->getName()] = $this->createMethods($classReflection, $instanceReflection);
 
-                if (preg_match_all(
-                    '/@mixin\s+([\w\\\\]+)/',
-                    (string) $instanceReflection->getNativeReflection()->getDocComment(),
-                    $mixins
-                )) {
-                    foreach ($mixins[1] as $mixin) {
+                foreach ($this->annotationsHelper->getMixins($instanceReflection) as $mixin) {
+                    try {
                         $mixinInstanceReflection = $this->broker->getClass($mixin);
-                        $this->methods[$classReflection->getName()] += $this->createMethods($classReflection, $mixinInstanceReflection);
+                    } catch (ClassNotFoundException $e) {
+                        continue;
                     }
+                    $this->methods[$classReflection->getName()] += $this->createMethods($classReflection, $mixinInstanceReflection);
                 }
 
                 if (isset($this->extensions[$instanceReflection->getName()])) {

--- a/src/Utils/AnnotationsHelper.php
+++ b/src/Utils/AnnotationsHelper.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Weebly\PHPStan\Laravel\Utils;
+
+use PHPStan\Reflection\ClassReflection;
+
+class AnnotationsHelper
+{
+    /**
+     * Resolve class mixins from doc block
+     *
+     * @param ClassReflection $reflection
+     * @return array
+     */
+    public function getMixins(ClassReflection $reflection) : array
+    {
+        preg_match_all(
+            '/@mixin\s+([\w\\\\]+)/',
+            (string) $reflection->getNativeReflection()->getDocComment(),
+            $mixins
+        );
+
+        return array_map(function ($mixin) {
+            return preg_replace('#^\\\\#', '', $mixin);
+        }, $mixins[1]);
+    }
+}

--- a/tests/BuilderMethodExtensionTest.php
+++ b/tests/BuilderMethodExtensionTest.php
@@ -13,6 +13,8 @@ use Illuminate\Database\Eloquent\Model;
 use Weebly\PHPStan\Laravel\BuilderMethodExtension;
 use stdClass;
 use Illuminate\Database\Eloquent\Builder;
+use Weebly\PHPStan\Laravel\Utils\AnnotationsHelper;
+use PHPStan\Broker\ClassNotFoundException;
 
 /**
  * @package Tests\Weebly\PHPStan\Laravel
@@ -24,28 +26,45 @@ class BuilderMethodExtensionTest extends TestCase
      */
     private $broker;
 
+    /**
+     * @var string
+     */
+    private $childOfModelClassName;
+
     public function testHasMethodInSubclassOfModel()
     {
-        $this->assertFalse($this->hasMethod(stdClass::class, 'find'));
-        $this->assertTrue($this->hasMethod(ChildOfModel::class, 'find'));
-        $this->assertFalse($this->hasMethod(stdClass::class, 'select'));
-        $this->assertTrue($this->hasMethod(ChildOfModel::class, 'select'));
+        try {
+            $this->assertFalse($this->hasMethod(stdClass::class, 'find'));
+            $this->assertTrue($this->hasMethod($this->childOfModelClassName, 'find'));
+            $this->assertFalse($this->hasMethod(stdClass::class, 'select'));
+            $this->assertTrue($this->hasMethod($this->childOfModelClassName, 'select'));
+        } catch (ClassNotFoundException $e) {
+            $this->markTestIncomplete($e->getMessage());
+        }
     }
 
     public function testHasMethodInClassWithMixinAnnotation()
     {
-        $this->assertFalse($this->hasMethod(stdClass::class, 'find'));
-        $this->assertTrue($this->hasMethod(HasAMixinAnnotation::class, 'find'));
-        $this->assertFalse($this->hasMethod(stdClass::class, 'select'));
-        $this->assertTrue($this->hasMethod(HasAMixinAnnotation::class, 'select'));
+        try {
+            $this->assertFalse($this->hasMethod(stdClass::class, 'find'));
+            $this->assertTrue($this->hasMethod(stdClass::class, 'find', true));
+            $this->assertFalse($this->hasMethod(stdClass::class, 'select'));
+            $this->assertTrue($this->hasMethod(stdClass::class, 'select', true));
+        } catch (ClassNotFoundException $e) {
+            $this->markTestIncomplete($e->getMessage());
+        }
     }
 
     public function testHasMethodInBuilder()
     {
-        $this->assertFalse($this->hasMethod(stdClass::class, 'find'));
-        $this->assertTrue($this->hasMethod(Builder::class, 'find'));
-        $this->assertFalse($this->hasMethod(stdClass::class, 'select'));
-        $this->assertTrue($this->hasMethod(Builder::class, 'select'));
+        try {
+            $this->assertFalse($this->hasMethod(stdClass::class, 'find'));
+            $this->assertTrue($this->hasMethod(Builder::class, 'find'));
+            $this->assertFalse($this->hasMethod(stdClass::class, 'select'));
+            $this->assertTrue($this->hasMethod(Builder::class, 'select'));
+        } catch (ClassNotFoundException $e) {
+            $this->markTestIncomplete($e->getMessage());
+        }
     }
 
     /**
@@ -55,6 +74,7 @@ class BuilderMethodExtensionTest extends TestCase
     {
         parent::setUp();
         $this->broker = $this->createBroker();
+        $this->childOfModelClassName = get_class(new class() extends Model {});
     }
 
     /**
@@ -82,23 +102,32 @@ class BuilderMethodExtensionTest extends TestCase
      *
      * @param string $className
      * @param string $methodName
+     * @param bool $addBuilderMixin
      * @return bool
+     * @throws ClassNotFoundException
      */
-    private function hasMethod(string $className, string $methodName): bool
+    private function hasMethod(string $className, string $methodName, bool $addBuilderMixin = false): bool
     {
-        $extension = new BuilderMethodExtension($this->makeMethodReflectionFactoryMock());
+        $extension = new BuilderMethodExtension(
+            $this->makeMethodReflectionFactoryMock(),
+            $this->makeAnnotationsHelperMock($addBuilderMixin)
+        );
         $extension->setBroker($this->broker);
 
         return $extension->hasMethod($this->broker->getClass($className), $methodName);
     }
+
+    /**
+     * @param bool $withBuilder
+     * @return AnnotationsHelper|MockObject
+     */
+    private function makeAnnotationsHelperMock(bool $withBuilder = false)
+    {
+        $annotationsHelper = $this
+            ->getMockBuilder(AnnotationsHelper::class)
+            ->getMock();
+        $annotationsHelper->method('getMixins')->willReturn($withBuilder ? [Builder::class] : []);
+
+        return $annotationsHelper;
+    }
 }
-
-class ChildOfModel extends Model {}
-
-/**
- * Some description
- *
- * @mixin \Illuminate\Database\Eloquent\Builder
- * @method string getString()
- */
-class HasAMixinAnnotation {}

--- a/tests/BuilderMethodExtensionTest.php
+++ b/tests/BuilderMethodExtensionTest.php
@@ -1,0 +1,104 @@
+<?php declare(strict_types = 1);
+
+namespace Tests\Weebly\PHPStan\Laravel;
+
+use PHPStan\Testing\TestCase;
+use PHPStan\Broker\Broker;
+use Weebly\PHPStan\Laravel\MethodReflectionFactory;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPStan\Reflection\Php\PhpMethodReflectionFactory;
+use PHPStan\Reflection\Php\PhpMethodReflection;
+use PHPStan\Type\FileTypeMapper;
+use Illuminate\Database\Eloquent\Model;
+use Weebly\PHPStan\Laravel\BuilderMethodExtension;
+use stdClass;
+use Illuminate\Database\Eloquent\Builder;
+
+/**
+ * @package Tests\Weebly\PHPStan\Laravel
+ */
+class BuilderMethodExtensionTest extends TestCase
+{
+    /**
+     * @var Broker
+     */
+    private $broker;
+
+    public function testHasMethodInSubclassOfModel()
+    {
+        $this->assertFalse($this->hasMethod(stdClass::class, 'find'));
+        $this->assertTrue($this->hasMethod(ChildOfModel::class, 'find'));
+        $this->assertFalse($this->hasMethod(stdClass::class, 'select'));
+        $this->assertTrue($this->hasMethod(ChildOfModel::class, 'select'));
+    }
+
+    public function testHasMethodInClassWithMixinAnnotation()
+    {
+        $this->assertFalse($this->hasMethod(stdClass::class, 'find'));
+        $this->assertTrue($this->hasMethod(HasAMixinAnnotation::class, 'find'));
+        $this->assertFalse($this->hasMethod(stdClass::class, 'select'));
+        $this->assertTrue($this->hasMethod(HasAMixinAnnotation::class, 'select'));
+    }
+
+    public function testHasMethodInBuilder()
+    {
+        $this->assertFalse($this->hasMethod(stdClass::class, 'find'));
+        $this->assertTrue($this->hasMethod(Builder::class, 'find'));
+        $this->assertFalse($this->hasMethod(stdClass::class, 'select'));
+        $this->assertTrue($this->hasMethod(Builder::class, 'select'));
+    }
+
+    /**
+     * @inheritdoc
+     */
+    protected function setUp()
+    {
+        parent::setUp();
+        $this->broker = $this->createBroker();
+    }
+
+    /**
+     * @return MethodReflectionFactory
+     */
+    private function makeMethodReflectionFactoryMock()
+    {
+        /** @var MockObject|PhpMethodReflectionFactory $phpMethodReflectionFactory */
+        $phpMethodReflectionFactory = $this
+            ->getMockBuilder(PhpMethodReflectionFactory::class)
+            ->getMockForAbstractClass();
+        $methodReflectionMock = $this
+            ->getMockBuilder(PhpMethodReflection::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $phpMethodReflectionFactory->method('create')->willReturn($methodReflectionMock);
+        /** @var FileTypeMapper $fileTypeMapper */
+        $fileTypeMapper = $this->getContainer()->createInstance(FileTypeMapper::class);
+
+        return new MethodReflectionFactory($phpMethodReflectionFactory, $fileTypeMapper);
+    }
+
+    /**
+     * Check existence of the method in given class
+     *
+     * @param string $className
+     * @param string $methodName
+     * @return bool
+     */
+    private function hasMethod(string $className, string $methodName): bool
+    {
+        $extension = new BuilderMethodExtension($this->makeMethodReflectionFactoryMock());
+        $extension->setBroker($this->broker);
+
+        return $extension->hasMethod($this->broker->getClass($className), $methodName);
+    }
+}
+
+class ChildOfModel extends Model {}
+
+/**
+ * Some description
+ *
+ * @mixin \Illuminate\Database\Eloquent\Builder
+ * @method string getString()
+ */
+class HasAMixinAnnotation {}

--- a/tests/FacadeMethodExtensionTest.php
+++ b/tests/FacadeMethodExtensionTest.php
@@ -1,0 +1,98 @@
+<?php
+
+namespace Tests\Weebly\PHPStan\Laravel;
+
+use PHPStan\Testing\TestCase;
+use PHPStan\Broker\Broker;
+use Weebly\PHPStan\Laravel\MethodReflectionFactory;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPStan\Reflection\Php\PhpMethodReflectionFactory;
+use PHPStan\Reflection\Php\PhpMethodReflection;
+use PHPStan\Type\FileTypeMapper;
+use Weebly\PHPStan\Laravel\FacadeMethodExtension;
+use Illuminate\Support\Facades\Facade;
+
+/**
+ * @package Tests\Weebly\PHPStan\Laravel
+ */
+class FacadeMethodExtensionTest extends TestCase
+{
+    /**
+     * @var Broker
+     */
+    private $broker;
+
+    public function testHasMethod()
+    {
+        // Native accessor method
+        $this->assertTrue($this->hasMethod(TestFacade::class, 'someMethod'));
+        $this->assertFalse($this->hasMethod(TestFacade::class, 'fakeMethod'));
+        // Method from accessor mixin
+        $this->assertTrue($this->hasMethod(TestFacade::class, 'table'));
+        $this->assertTrue($this->hasMethod(TestFacade::class, 'shouldUse'));
+    }
+
+    /**
+     * @inheritdoc
+     */
+    protected function setUp()
+    {
+        parent::setUp();
+        $this->broker = $this->createBroker();
+    }
+
+    /**
+     * @return MethodReflectionFactory
+     */
+    private function makeMethodReflectionFactoryMock()
+    {
+        /** @var MockObject|PhpMethodReflectionFactory $phpMethodReflectionFactory */
+        $phpMethodReflectionFactory = $this
+            ->getMockBuilder(PhpMethodReflectionFactory::class)
+            ->getMockForAbstractClass();
+        $methodReflectionMock = $this
+            ->getMockBuilder(PhpMethodReflection::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $phpMethodReflectionFactory->method('create')->willReturn($methodReflectionMock);
+        /** @var FileTypeMapper $fileTypeMapper */
+        $fileTypeMapper = $this->getContainer()->createInstance(FileTypeMapper::class);
+
+        return new MethodReflectionFactory($phpMethodReflectionFactory, $fileTypeMapper);
+    }
+
+    /**
+     * Check existence of the method in given class
+     *
+     * @param string $className
+     * @param string $methodName
+     * @return bool
+     */
+    private function hasMethod(string $className, string $methodName): bool
+    {
+        $extension = new FacadeMethodExtension($this->makeMethodReflectionFactoryMock());
+        $extension->setBroker($this->broker);
+
+        return $extension->hasMethod($this->broker->getClass($className), $methodName);
+    }
+}
+
+/**
+ * @mixin \Illuminate\Database\Connection
+ * @mixin \Illuminate\Auth\AuthManager
+ */
+class TestFacadeAccessor {
+    function someMethod() {
+        return true;
+    }
+}
+
+class TestFacade extends Facade {
+    /**
+     * @inheritdoc
+     */
+    protected static function getFacadeAccessor()
+    {
+        return new TestFacadeAccessor();
+    }
+}

--- a/tests/Utils/AnnotationsHelperTest.php
+++ b/tests/Utils/AnnotationsHelperTest.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Tests\Weebly\PHPStan\Laravel\Utils;
+
+use PHPUnit\Framework\TestCase;
+use PHPStan\Reflection\ClassReflection;
+use PHPUnit\Framework\MockObject\MockObject;
+use ReflectionClass;
+use Weebly\PHPStan\Laravel\Utils\AnnotationsHelper;
+
+class AnnotationsHelperTest extends TestCase
+{
+    public function testGetMixins()
+    {
+        $annotationHelper = new AnnotationsHelper();
+        $reflection = $this->makeClassReflectionMock(<<<EOF
+/**
+ * Class AnnotationsHelperTest
+ * @package Tests\Weebly\PHPStan\Laravel\Utils
+ * @mixin \PHPUnit\Framework\TestCase
+ *
+ * @mixin PHPStan\Reflection\ClassReflection
+ */
+EOF
+);
+        $this->assertEquals(
+            [TestCase::class, ClassReflection::class],
+            $annotationHelper->getMixins($reflection)
+        );
+        $this->assertEquals(
+            [],
+            $annotationHelper->getMixins($this->makeClassReflectionMock(''))
+        );
+    }
+
+    /**
+     * @param string $docBlock
+     * @return ClassReflection|MockObject
+     */
+    private function makeClassReflectionMock(string $docBlock)
+    {
+        $reflectionClass = $this
+            ->getMockBuilder(ReflectionClass::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $reflectionClass->method('getDocComment')->willReturn($docBlock);
+
+        $classReflection = $this
+            ->getMockBuilder(ClassReflection::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $classReflection->method('getNativeReflection')->willReturn($reflectionClass);
+
+        return $classReflection;
+    }
+}


### PR DESCRIPTION
There are classes in Laravel which may be used as query builder and it's indicated via @mixin annotation, for example, [relations](https://github.com/illuminate/database/blob/master/Eloquent/Relations/Relation.php). I guess, it is useful to consider this moment.