### PR TITLE
Require PHP 7 and add patch version to PHPStan

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: php
 
 php:
-  - 7.0
   - 7.1
   - 7.2
 

--- a/composer.json
+++ b/composer.json
@@ -10,8 +10,9 @@
         }
     ],
     "require": {
+        "php": "^7.1",
         "laravel/framework": "5.5.* || 5.6.*",
-        "phpstan/phpstan": "^0.9"
+        "phpstan/phpstan": "^0.9.2"
     },
     "require-dev": {
         "phpunit/phpunit": "^6.5.2"


### PR DESCRIPTION
I'd like to suggest that we add PHP 7 requirement to our `composer.json`, as well add the patch version for PHPStan as is has several fixes :+1: 