### PR TITLE
[WIP] Very rudimentary starting point for Model::where*() methods

### DIFF
--- a/src/CustomMethod.php
+++ b/src/CustomMethod.php
@@ -1,0 +1,78 @@
+<?php declare(strict_types = 1);
+
+namespace Weebly\PHPStan\Laravel;
+
+use PHPStan\Reflection\ClassReflection;
+use PHPStan\Reflection\MethodReflection;
+use PHPStan\Type\ObjectType;
+use PHPStan\Type\Type;
+use PHPStan\Type\UnionType;
+
+class CustomMethod implements MethodReflection
+{
+    protected $class;
+    protected $name;
+    protected $returnType;
+
+    public function __construct(
+        ClassReflection $class,
+        string $name,
+        $returnType
+    ) {
+        $this->class = $class;
+        $this->name = $name;
+        $this->returnType = $returnType;
+    }
+
+    public function getDeclaringClass(): ClassReflection
+    {
+        return $this->class;
+    }
+
+    public function getPrototype(): MethodReflection
+    {
+        return $this;
+    }
+
+    public function isStatic(): bool
+    {
+        return true;
+    }
+
+    public function isPrivate(): bool
+    {
+        return false;
+    }
+
+    public function isPublic(): bool
+    {
+        return true;
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    /**
+     * @return \PHPStan\Reflection\ParameterReflection[]
+     */
+    public function getParameters(): array
+    {
+        return [];
+    }
+
+    public function isVariadic(): bool
+    {
+        return true;
+    }
+
+    public function getReturnType(): Type
+    {
+        if (is_array($this->returnType)) {
+            return new UnionType($this->returnType);
+        }
+
+        return new ObjectType($this->returnType);
+    }
+}


### PR DESCRIPTION
So far this code fixes any errors with where*() methods, except for more complicated cases. 

For reference

* Dynamic where()s are handled in [`Query\Builder::__call()`](https://github.com/laravel/framework/blob/5.6/src/Illuminate/Database/Query/Builder.php#L2668)
* Code parsing them is [`Query\Builder::dynamicWhere()`](https://github.com/laravel/framework/blob/5.6/src/Illuminate/Database/Query/Builder.php#L1443)

You seem to be able to call methods such as `Model::whereEmailAndName($email, $name)` and `Model::whereEmailOrEmail($email, $otherEmail)` but I haven't ever used these and would have to do more research.

Feel free to comment and contribute, as this is far from ready to be merged.