### PR TITLE
Fixing problem when core LARAVEL_START constant is used

### DIFF
--- a/bootstrap.php
+++ b/bootstrap.php
@@ -1,5 +1,7 @@
 <?php declare(strict_types = 1);
 
+define('LARAVEL_START', microtime(true));
+
 $app = require_once __DIR__ . '/../../../bootstrap/app.php';
 
 $app->make(\Illuminate\Contracts\Console\Kernel::class)->bootstrap();


### PR DESCRIPTION
Laravel has a constant defined on [./artisan](https://github.com/laravel/laravel/blob/master/artisan) and [./public/index.php](https://github.com/laravel/laravel/blob/master/public/index.php#L10):

```php
define('LARAVEL_START', microtime(true));
```

If you use this contant on your code, you get errors like:

```
 ------ ---------------------------------------------------------------- 
  Line   app/Providers/AppServiceProvider.php                            
 ------ ---------------------------------------------------------------- 
  24     Constant LARAVEL_START not found.                               
  26     Constant LARAVEL_START not found.                               
 ------ ---------------------------------------------------------------- 
```