### PR TITLE
replace words `extension`/`plugin` with `package`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # phpstan-laravel
-Laravel plugins for [PHPStan](https://github.com/phpstan/phpstan)
+Laravel package for [PHPStan](https://github.com/phpstan/phpstan)
 
 [![Build Status](https://img.shields.io/travis/Weebly/phpstan-laravel/master.svg?style=flat-square)](https://travis-ci.org/Weebly/phpstan-laravel)
 
 ## Usage
 
-To use this extension, require it in [Composer](https://getcomposer.org/):
+To use this package, require it in [Composer](https://getcomposer.org/):
 
 ```
 composer require --dev weebly/phpstan-laravel


### PR DESCRIPTION
Laravel doc uses the noun `package` to describe those libs (see https://laravel.com/docs/5.6/packages).